### PR TITLE
Flutter Downgrade to support downgraded 2p3p AARs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 
@@ -47,7 +47,7 @@ android {
 
         implementation 'androidx.appcompat:appcompat:1.0.1'
         implementation "androidx.core:core-ktx:1.6.0"
-        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.31"
+        implementation "org.jetbrains.kotlin:kotlin-stdlib:1.6.21"
         implementation 'com.google.code.gson:gson:2.8.8'
         implementation 'io.sentry:sentry:6.21.0'
         implementation 'com.squareup.retrofit2:retrofit:2.9.0'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+kotlin_version=1.6.21

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Aug 21 14:55:09 IST 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/android/src/main/java/com/razorpay/flutter_customui/RazorpayDelegate.java
+++ b/android/src/main/java/com/razorpay/flutter_customui/RazorpayDelegate.java
@@ -312,7 +312,7 @@ public class RazorpayDelegate implements ActivityResultListener {
     void linkNewUpiAccount(String mobileNumber, Result result, EventChannel.EventSink eventSink) {
         this.pendingResult = result;
         this.eventSink = eventSink;
-        razorpay.upiTurbo.linkNewUpiAccount(mobileNumber, new UpiTurboLinkAccountListener() {
+        razorpay.upiTurbo.linkNewUpiAccount(mobileNumber, null, new UpiTurboLinkAccountListener() {
             @Override
             public void onResponse(@NonNull UpiTurboLinkAction upiTurboLinkAction) {
                 onUpiTurboResponse(upiTurboLinkAction);
@@ -393,7 +393,7 @@ public class RazorpayDelegate implements ActivityResultListener {
         this.pendingResult = result;
         this.eventSink = eventSink;
         HashMap<Object, Object> reply = new HashMap<>();
-        razorpay.upiTurbo.getLinkedUpiAccounts(mobileNumber, new UpiTurboResultListener() {
+        razorpay.upiTurbo.getLinkedUpiAccounts(mobileNumber, null, new UpiTurboResultListener() {
             @Override
             public void onSuccess(@NonNull List<UpiAccount> upiAccounts) {
                 if (upiAccounts.isEmpty()) {
@@ -681,8 +681,10 @@ public class RazorpayDelegate implements ActivityResultListener {
                             List<Object> pinSetArr = new ArrayList<>();
 
                             if (allAccounts.getAccountsWithPinNotSet() != null) {
-                                for (BankAccount account : allAccounts.getAccountsWithPinNotSet()) {
-                                    pinNotSetArr.add(account);
+                                for (Object account : allAccounts.getAccountsWithPinNotSet()) {
+                                    if (account instanceof BankAccount) {
+                                        pinNotSetArr.add((BankAccount) account);
+                                    }
                                 }
                             }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,11 +1,13 @@
 buildscript {
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Aug 21 14:53:04 IST 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -100,8 +100,8 @@ class _MyHomePageState extends State<MyHomePage> {
                           );
                         },
                         child: Text('Purchase'),
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.green,
+                        style: ButtonStyle(
+                          backgroundColor: MaterialStateProperty.all(Colors.green),
                         ),
                       )
                     ],


### PR DESCRIPTION
### Details
- Tested on Flutter v2.10.5
- Kotlin Version 1.6.21
- Gradle Version 7.4.2

### Note
- Flutter needs to be manually downgraded to version 2.10.5
