### PR TITLE
Update RazorpayDelegate.java to handle crash

### DIFF
--- a/android/src/main/java/com/razorpay/flutter_customui/RazorpayDelegate.java
+++ b/android/src/main/java/com/razorpay/flutter_customui/RazorpayDelegate.java
@@ -118,21 +118,29 @@ public class RazorpayDelegate implements ActivityResultListener  {
 
     void getPaymentMethods(final Result result) {
         pendingResult = result;
+        hasSubmittedResult = false; // reset for this call
+
         if (razorpay == null) {
             init(this.key, result);
         }
-        razorpay.getPaymentMethods(new PaymentMethodsCallback() {
-            @Override
-            public void onPaymentMethodsReceived(String s) {
+    razorpay.getPaymentMethods(new PaymentMethodsCallback() {
+        @Override
+        public void onPaymentMethodsReceived(String s) {
+            if (!hasSubmittedResult) {
+                hasSubmittedResult = true;
                 HashMap<String, Object> hMapData = new Gson().fromJson(s, HashMap.class);
                 pendingResult.success(hMapData);
             }
+        }
 
-            @Override
-            public void onError(String s) {
+        @Override
+        public void onError(String s) {
+            if (!hasSubmittedResult) {
+                hasSubmittedResult = true;
                 pendingResult.error(s, "", null);
             }
-        });
+        }
+    });
     }
 
     void getAppsWhichSupportUpi(Result result) {


### PR DESCRIPTION
Fixed crash of Reply already submitted

## Note :- Please follow the below points while attaching test cases document link below:
   ### - If label `Tested` is added then test cases document URL is mandatory.
   ### - Link added should be a valid URL and accessible throughout the org.
   ### - If the branch name contains hotfix / revert by default the BVT workflow check will pass.

| Test Case Document URL                        |
|-----------------------------------------------|
| Please paste test case document link here.... |

Crash Stack trace:

          Fatal Exception: java.lang.IllegalStateException: Reply already submitted
       at io.flutter.embedding.engine.dart.DartMessenger$Reply.reply(DartMessenger.java:35)
       at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler$1.success(MethodChannel.java:14)
       at com.razorpay.flutter_customui.RazorpayDelegate$1.onPaymentMethodsReceived(RazorpayDelegate.java:19)
       at com.razorpay.BaseRazorpay$6.onResponse(BaseRazorpay.java:6)
       at com.razorpay.BaseRazorpay$8.run(BaseRazorpay.java:35)
       at com.razorpay.Q$$U_.onPostExecute(Q.java:6)
       at android.os.AsyncTask.finish(AsyncTask.java:771)
       at android.os.AsyncTask.-$$Nest$mfinish()
       at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:788)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:230)
       at android.os.Looper.loop(Looper.java:319)
       at android.app.ActivityThread.main(ActivityThread.java:8919)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:578)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1103)
