### PR TITLE
Feat: Added functions for amazon linking and paying

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,12 +16,16 @@ rootProject.allprojects {
     repositories {
         mavenCentral()
         google()
+        flatDir {
+            dirs project(':razorpay_flutter_customui').file('libs')
+        }
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.razorpay.flutter_customui'
     compileSdkVersion 31
 
     defaultConfig {
@@ -31,9 +35,18 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-/*        implementation fileTree(include: ['*.jar'], dir: 'libs')
-        implementation fileTree(dir: 'libs', include: ['*.aar'])
-        implementation 'com.razorpay:customui:3.9.+'*/
+        // JARs from libs/ (includes turbo-plugin-classes.jar for UPI Turbo listener interfaces)
+        // implementation fileTree(include: ['*.jar'], dir: 'libs')
+        // Maven deps for transitive dependencies needed by the local AARs
+        // compileOnly 'com.razorpay:turbo-headless:2.1.7'
+        // compileOnly 'com.razorpay:turbo-ui:2.1.7'
+        // compileOnly 'com.razorpay:core:1.0.6'
+        // Amazon Pay SDK deps (required by amazonpay-wallet-paylater at runtime)
+        implementation 'com.amazon.android.amazonpay:apay-android-super-sdk-wallet:1.3.2'
+        implementation 'com.amazon.android.amazonpay:apay-android-sdk-common-lib:1.3.8'
+        implementation 'com.amazon.android.amazonpay:apay-identity-mobile-android-sdk-sso:3.2.6'
+        implementation 'commons-codec:commons-codec:1.16.0'
+        implementation 'org.apache.commons:commons-lang3:3.7'
         implementation 'com.android.support:cardview-v7:26.1.0'
 
         implementation 'androidx.core:core-ktx:1.7.0'
@@ -53,9 +66,9 @@ android {
         implementation 'com.squareup.retrofit2:retrofit:2.9.0'
         implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
         implementation 'com.squareup.okhttp3:logging-interceptor:4.10.0'
+        implementation 'com.razorpay:customui-core:3.10.6'
+        implementation 'com.razorpay:amazonpay-wallet-paylater:1.0.0'
         //TODO: Add Library folder path in implementation's dir
         //compileOnly fileTree(include: ['*.aar'], dir: '')
     }
 }
-
-

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,16 +16,12 @@ rootProject.allprojects {
     repositories {
         mavenCentral()
         google()
-        flatDir {
-            dirs project(':razorpay_flutter_customui').file('libs')
-        }
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'com.razorpay.flutter_customui'
     compileSdkVersion 31
 
     defaultConfig {

--- a/android/src/main/java/com/razorpay/flutter_customui/RazorpayDelegate.java
+++ b/android/src/main/java/com/razorpay/flutter_customui/RazorpayDelegate.java
@@ -569,8 +569,20 @@ public class RazorpayDelegate implements ActivityResultListener  {
      * On success, we also need to handle onActivityResult from the Amazon SDK.
      */
     public void amazonPayStartAuthorization(String customerId, Result result) {
-        this.pendingResult = result;
+        // Use local reference — don't overwrite shared pendingResult to avoid "Reply already submitted" crash
+        final Result amazonPayResult = result;
         HashMap<Object, Object> reply = new HashMap<>();
+
+        // Log all fields on the razorpay object for debugging
+        try {
+            java.lang.reflect.Field[] fields = razorpay.getClass().getFields();
+            for (java.lang.reflect.Field f : fields) {
+                Object val = null;
+                try { val = f.get(razorpay); } catch (Exception ignored) {}
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "[AmazonPay] Error listing fields: " + e.getMessage());
+        }
 
         try {
             // Use reflection to access amazonPayWallet field (may not exist at compile time)
@@ -578,12 +590,13 @@ public class RazorpayDelegate implements ActivityResultListener  {
             Object amazonPayWallet = apayField.get(razorpay);
 
             if (amazonPayWallet == null) {
+                Log.e(TAG, "[AmazonPay] amazonPayWallet is null!");
                 reply.put("type", "error");
                 reply.put("data", new HashMap<Object, Object>() {{
                     put("code", -1);
                     put("message", "amazonPayWallet is null. SDK may not be initialized with Amazon Pay plugin.");
                 }});
-                pendingResult.success(reply);
+                amazonPayResult.success(reply);
                 return;
             }
 
@@ -600,33 +613,62 @@ public class RazorpayDelegate implements ActivityResultListener  {
                             put("customerId", customerId);
                             put("status", "linked");
                         }});
-                        new Handler(Looper.getMainLooper()).post(() -> pendingResult.success(reply));
-                    } else if ("onLinkingFailed".equals(methodName)) {
+                        new Handler(Looper.getMainLooper()).post(() -> amazonPayResult.success(reply));
+                    } else if ("onLinkingError".equals(methodName)) {
+                        // AmazonPayAuthCodeCallback.onLinkingError(code: Int, message: String)
                         int errorCode = args != null && args.length > 0 ? (int) args[0] : -1;
                         String errorMsg = args != null && args.length > 1 ? (String) args[1] : "Unknown error";
+                        Log.e(TAG, "[AmazonPay] onLinkingError: code=" + errorCode + " msg=" + errorMsg);
                         reply.put("type", "error");
                         reply.put("data", new HashMap<Object, Object>() {{
                             put("code", errorCode);
                             put("message", errorMsg);
                         }});
-                        new Handler(Looper.getMainLooper()).post(() -> pendingResult.success(reply));
+                        new Handler(Looper.getMainLooper()).post(() -> amazonPayResult.success(reply));
                     }
                     return null;
                 }
             );
 
             // Call startAuthorization(activity, customerId, callback) via reflection
+            // Note: Kotlin `Any` compiles to java.lang.Object, so the method signature is
+            // startAuthorization(Activity, String, Object), NOT startAuthorization(Activity, String, AmazonPayAuthCodeCallback)
             java.lang.reflect.Method startAuth = amazonPayWallet.getClass().getMethod(
-                "startAuthorization", android.app.Activity.class, String.class, callbackClass);
+                "startAuthorization", android.app.Activity.class, String.class, Object.class);
             startAuth.invoke(amazonPayWallet, activity, customerId, callbackProxy);
 
-        } catch (Exception e) {
+        } catch (NoSuchFieldException e) {
+            Log.e(TAG, "[AmazonPay] FIELD NOT FOUND: 'amazonPayWallet' does not exist on " + razorpay.getClass().getName(), e);
             reply.put("type", "error");
             reply.put("data", new HashMap<Object, Object>() {{
                 put("code", -1);
-                put("message", "Amazon Pay SDK not available: " + e.getMessage());
+                put("message", "amazonPayWallet field not found: " + e.getMessage());
             }});
-            pendingResult.success(reply);
+            amazonPayResult.success(reply);
+        } catch (ClassNotFoundException e) {
+            Log.e(TAG, "[AmazonPay] CLASS NOT FOUND: AmazonPayAuthCodeCallback", e);
+            reply.put("type", "error");
+            reply.put("data", new HashMap<Object, Object>() {{
+                put("code", -1);
+                put("message", "AmazonPayAuthCodeCallback class not found: " + e.getMessage());
+            }});
+            amazonPayResult.success(reply);
+        } catch (NoSuchMethodException e) {
+            Log.e(TAG, "[AmazonPay] METHOD NOT FOUND: startAuthorization", e);
+            reply.put("type", "error");
+            reply.put("data", new HashMap<Object, Object>() {{
+                put("code", -1);
+                put("message", "startAuthorization method not found: " + e.getMessage());
+            }});
+            amazonPayResult.success(reply);
+        } catch (Exception e) {
+            Log.e(TAG, "[AmazonPay] UNEXPECTED ERROR: " + e.getClass().getName() + ": " + e.getMessage(), e);
+            reply.put("type", "error");
+            reply.put("data", new HashMap<Object, Object>() {{
+                put("code", -1);
+                put("message", "Amazon Pay error: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+            }});
+            amazonPayResult.success(reply);
         }
     }
 
@@ -635,10 +677,15 @@ public class RazorpayDelegate implements ActivityResultListener  {
      */
     public void isAmazonPayAvailable(Result result) {
         try {
-            // Check for the amazonPayWallet field on Razorpay
             java.lang.reflect.Field field = razorpay.getClass().getField("amazonPayWallet");
-            result.success(field != null);
+            Object value = field.get(razorpay);
+            // Check the field VALUE is non-null, not just that the field exists
+            boolean available = value != null;
+            result.success(available);
         } catch (NoSuchFieldException e) {
+            result.success(false);
+        } catch (Exception e) {
+            Log.e(TAG, "[AmazonPay] isAmazonPayAvailable error: " + e.getMessage(), e);
             result.success(false);
         }
     }

--- a/android/src/main/java/com/razorpay/flutter_customui/RazorpayDelegate.java
+++ b/android/src/main/java/com/razorpay/flutter_customui/RazorpayDelegate.java
@@ -294,7 +294,7 @@ public class RazorpayDelegate implements ActivityResultListener  {
     void linkNewUpiAccount(String mobileNumber, Result result, EventChannel.EventSink eventSink){
         this.pendingResult = result;
         this.eventSink = eventSink;
-        razorpay.upiTurbo.linkNewUpiAccount(mobileNumber, new UpiTurboLinkAccountListener() {
+        razorpay.upiTurbo.linkNewUpiAccount(mobileNumber, "", new UpiTurboLinkAccountListener() {
             @Override
             public void onResponse(@NonNull UpiTurboLinkAction upiTurboLinkAction) {
                 onUpiTurboResponse(upiTurboLinkAction);
@@ -372,7 +372,7 @@ public class RazorpayDelegate implements ActivityResultListener  {
         this.pendingResult = result;
         this.eventSink = eventSink;
         HashMap<Object, Object> reply = new HashMap<>();
-        razorpay.upiTurbo.getLinkedUpiAccounts(mobileNumber, new UpiTurboResultListener() {
+        razorpay.upiTurbo.getLinkedUpiAccounts(mobileNumber, "", new UpiTurboResultListener() {
             @Override
             public void onSuccess(@NonNull List<UpiAccount> upiAccounts) {
                 if(upiAccounts.isEmpty()){
@@ -573,29 +573,53 @@ public class RazorpayDelegate implements ActivityResultListener  {
         HashMap<Object, Object> reply = new HashMap<>();
 
         try {
-            razorpay.amazonPayWallet.startAuthorization(activity, customerId,
-                new com.razorpay.AmazonPayAuthCodeCallback() {
-                    @Override
-                    public void onLinkingSuccessful() {
+            // Use reflection to access amazonPayWallet field (may not exist at compile time)
+            java.lang.reflect.Field apayField = razorpay.getClass().getField("amazonPayWallet");
+            Object amazonPayWallet = apayField.get(razorpay);
+
+            if (amazonPayWallet == null) {
+                reply.put("type", "error");
+                reply.put("data", new HashMap<Object, Object>() {{
+                    put("code", -1);
+                    put("message", "amazonPayWallet is null. SDK may not be initialized with Amazon Pay plugin.");
+                }});
+                pendingResult.success(reply);
+                return;
+            }
+
+            // Create callback proxy via reflection
+            Class<?> callbackClass = Class.forName("com.razorpay.AmazonPayAuthCodeCallback");
+            Object callbackProxy = java.lang.reflect.Proxy.newProxyInstance(
+                callbackClass.getClassLoader(),
+                new Class<?>[]{callbackClass},
+                (proxy, method, args) -> {
+                    String methodName = method.getName();
+                    if ("onLinkingSuccessful".equals(methodName)) {
                         reply.put("type", "success");
                         reply.put("data", new HashMap<Object, Object>() {{
                             put("customerId", customerId);
                             put("status", "linked");
                         }});
-                        pendingResult.success(reply);
-                    }
-
-                    @Override
-                    public void onLinkingFailed(int errorCode, String errorMessage) {
+                        new Handler(Looper.getMainLooper()).post(() -> pendingResult.success(reply));
+                    } else if ("onLinkingFailed".equals(methodName)) {
+                        int errorCode = args != null && args.length > 0 ? (int) args[0] : -1;
+                        String errorMsg = args != null && args.length > 1 ? (String) args[1] : "Unknown error";
                         reply.put("type", "error");
                         reply.put("data", new HashMap<Object, Object>() {{
                             put("code", errorCode);
-                            put("message", errorMessage);
+                            put("message", errorMsg);
                         }});
-                        pendingResult.success(reply);
+                        new Handler(Looper.getMainLooper()).post(() -> pendingResult.success(reply));
                     }
+                    return null;
                 }
             );
+
+            // Call startAuthorization(activity, customerId, callback) via reflection
+            java.lang.reflect.Method startAuth = amazonPayWallet.getClass().getMethod(
+                "startAuthorization", android.app.Activity.class, String.class, callbackClass);
+            startAuth.invoke(amazonPayWallet, activity, customerId, callbackProxy);
+
         } catch (Exception e) {
             reply.put("type", "error");
             reply.put("data", new HashMap<Object, Object>() {{
@@ -611,9 +635,10 @@ public class RazorpayDelegate implements ActivityResultListener  {
      */
     public void isAmazonPayAvailable(Result result) {
         try {
-            Class.forName("com.razorpay.AmazonPayAuthCodeCallback");
-            result.success(true);
-        } catch (ClassNotFoundException e) {
+            // Check for the amazonPayWallet field on Razorpay
+            java.lang.reflect.Field field = razorpay.getClass().getField("amazonPayWallet");
+            result.success(field != null);
+        } catch (NoSuchFieldException e) {
             result.success(false);
         }
     }
@@ -672,7 +697,7 @@ public class RazorpayDelegate implements ActivityResultListener  {
         this.pendingResult = result;
         this.eventSink = eventSink;
         HashMap<Object, Object> reply = new HashMap<>();
-        razorpay.upiTurbo.linkNewUpiAccountWithUI(customerMobile, new UpiTurboLinkAccountResultListener() {
+        razorpay.upiTurbo.linkNewUpiAccountWithUI(customerMobile, "", new UpiTurboLinkAccountResultListener() {
             @Override
             public void onSuccess(@NonNull List<UpiAccount> upiAccounts) {
                 if(upiAccounts.isEmpty()){
@@ -693,7 +718,7 @@ public class RazorpayDelegate implements ActivityResultListener  {
     public void manageUpiAccounts(String customerMobile,  Result result, EventChannel.EventSink eventSink){
         this.pendingResult = result;
         this.eventSink = eventSink;
-        razorpay.upiTurbo.manageUpiAccounts(customerMobile, new UpiTurboManageAccountListener() {
+        razorpay.upiTurbo.manageUpiAccounts(customerMobile, "", new UpiTurboManageAccountListener() {
             @Override
             public void onError(@NonNull JSONObject jsonObject) {
                 pendingResult.error("", jsonObject.toString(), jsonObject.toString());

--- a/android/src/main/java/com/razorpay/flutter_customui/RazorpayDelegate.java
+++ b/android/src/main/java/com/razorpay/flutter_customui/RazorpayDelegate.java
@@ -552,6 +552,72 @@ public class RazorpayDelegate implements ActivityResultListener  {
         razorpay.upiTurbo.onPermissionsRequestResult();
     }
 
+    // ──────────────────────────────────────────────
+    //  Amazon Pay Link-n-Pay
+    // ──────────────────────────────────────────────
+
+    /**
+     * Initiates Amazon Pay wallet linking flow.
+     *
+     * Calls the native Android SDK:
+     *   razorpay.amazonPayWallet.startAuthorization(activity, customerId, callback)
+     *
+     * The callback has two methods:
+     *   - onLinkingSuccessful(String authCode) — linking succeeded
+     *   - onLinkingFailed(int errorCode, String errorMessage) — linking failed
+     *
+     * On success, we also need to handle onActivityResult from the Amazon SDK.
+     */
+    public void amazonPayStartAuthorization(String customerId, Result result) {
+        this.pendingResult = result;
+        HashMap<Object, Object> reply = new HashMap<>();
+
+        try {
+            razorpay.amazonPayWallet.startAuthorization(activity, customerId,
+                new com.razorpay.AmazonPayAuthCodeCallback() {
+                    @Override
+                    public void onLinkingSuccessful() {
+                        reply.put("type", "success");
+                        reply.put("data", new HashMap<Object, Object>() {{
+                            put("customerId", customerId);
+                            put("status", "linked");
+                        }});
+                        pendingResult.success(reply);
+                    }
+
+                    @Override
+                    public void onLinkingFailed(int errorCode, String errorMessage) {
+                        reply.put("type", "error");
+                        reply.put("data", new HashMap<Object, Object>() {{
+                            put("code", errorCode);
+                            put("message", errorMessage);
+                        }});
+                        pendingResult.success(reply);
+                    }
+                }
+            );
+        } catch (Exception e) {
+            reply.put("type", "error");
+            reply.put("data", new HashMap<Object, Object>() {{
+                put("code", -1);
+                put("message", "Amazon Pay SDK not available: " + e.getMessage());
+            }});
+            pendingResult.success(reply);
+        }
+    }
+
+    /**
+     * Checks if the Amazon Pay SDK classes are available at runtime.
+     */
+    public void isAmazonPayAvailable(Result result) {
+        try {
+            Class.forName("com.razorpay.AmazonPayAuthCodeCallback");
+            result.success(true);
+        } catch (ClassNotFoundException e) {
+            result.success(false);
+        }
+    }
+
     public  boolean isTurboPluginAvailable(Result result, EventChannel.EventSink eventSink) {
         this.pendingResult = result;
         this.eventSink = eventSink;

--- a/android/src/main/java/com/razorpay/flutter_customui/RazorpayPlugin.java
+++ b/android/src/main/java/com/razorpay/flutter_customui/RazorpayPlugin.java
@@ -19,7 +19,6 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 
 import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** RazorpayFlutterCustomuiPlugin */
 
@@ -215,12 +214,7 @@ public class RazorpayPlugin  implements FlutterPlugin, MethodCallHandler, Activi
     this.eventChannel.setStreamHandler(null);
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.KITKAT)
-  public RazorpayPlugin(Registrar registrar) {
-    this.activity = registrar.activity();
-    this.razorpayDelegate = new RazorpayDelegate(registrar.activity());
-    registrar.addActivityResultListener(razorpayDelegate);
-  }
+  // Legacy v1 Flutter plugin registration removed (Registrar API deprecated)
 
   @RequiresApi(api = Build.VERSION_CODES.KITKAT)
   @Override

--- a/android/src/main/java/com/razorpay/flutter_customui/RazorpayPlugin.java
+++ b/android/src/main/java/com/razorpay/flutter_customui/RazorpayPlugin.java
@@ -192,6 +192,17 @@ public class RazorpayPlugin  implements FlutterPlugin, MethodCallHandler, Activi
         razorpayDelegate.manageUpiAccounts(customerMobile, result , this.eventSink);
         break;
 
+      // Amazon Pay Link-n-Pay
+      case "amazonPayStartAuthorization":
+        _arguments = call.arguments();
+        String amazonPayCustomerId = (String) _arguments.get("customerId");
+        razorpayDelegate.amazonPayStartAuthorization(amazonPayCustomerId, result);
+        break;
+
+      case "isAmazonPayAvailable":
+        razorpayDelegate.isAmazonPayAvailable(result);
+        break;
+
       default:
         Log.d(TAG,"no method");
     }

--- a/ios/Classes/RazorpayDelegate.swift
+++ b/ios/Classes/RazorpayDelegate.swift
@@ -70,7 +70,7 @@ class RazorpayDelegate: NSObject {
     
     public func getPaymentMethods(result: @escaping FlutterResult) {
         self.pendingResult = result
-        self.razorpay?.getPaymentMethods(withOptions: nil, withSuccessCallback: { successResponse in
+        RazorpayCheckout.getPaymentMethods(withOptions: nil, withSuccessCallback: { successResponse in
             self.pendingResult(successResponse  as NSDictionary)
         }, andFailureCallback: { errorResponse in
             self.pendingResult(errorResponse)
@@ -99,7 +99,7 @@ class RazorpayDelegate: NSObject {
     
     public func getSubscriptionAmount(subscriptionId: String, result: @escaping FlutterResult) {
         self.pendingResult = result
-        self.razorpay?.getSubscriptionAmount(havingSubscriptionId: subscriptionId, withSuccessCallback: { [weak self] successResponse in
+        RazorpayCheckout.getSubscriptionAmount(havingSubscriptionId: subscriptionId, withSuccessCallback: { [weak self] successResponse in
             self?.pendingResult(successResponse)
         }, andFailureCallback: { [weak self] errorResponse in
             self?.pendingResult(errorResponse)
@@ -160,13 +160,47 @@ extension RazorpayDelegate {
     }
     
     public func initilizeSDK(withKey key: String, result: @escaping FlutterResult) {
-            
+
         guard self.razorpay == nil else { return }
-        
+
         pendingResult = result
         self.configureWebView()
         if let unwrappedWebView = self.webView {
+            // Standard init
             self.razorpay = RazorpayCheckout.initWithKey(key, andDelegate: self, withPaymentWebView: unwrappedWebView)
+
+            // Set the amazonPlugin via setter if available
+            if let rzp = self.razorpay {
+                let setSelector = NSSelectorFromString("setAmazonPlugin:")
+                if rzp.responds(to: setSelector) {
+                    let entityClassNames = [
+                        "RazorpayApayWalletPaylater.WalletPaylaterEntity",
+                        "WalletPaylaterEntity",
+                        "_TtC26RazorpayApayWalletPaylater20WalletPaylaterEntity",
+                        "RazorpayApayWalletPaylater.AmazonWalletPaylater",
+                        "AmazonWalletPaylater",
+                        "_TtC26RazorpayApayWalletPaylater20AmazonWalletPaylater"
+                    ]
+
+                    for className in entityClassNames {
+                        if let cls = NSClassFromString(className) as? NSObject.Type {
+                            let pluginSel = NSSelectorFromString("pluginInstance")
+                            if cls.responds(to: pluginSel) {
+                                if let plugin = cls.perform(pluginSel)?.takeUnretainedValue() {
+                                    rzp.perform(setSelector, with: plugin)
+                                    break
+                                }
+                            }
+                            let initSel = NSSelectorFromString("init")
+                            if cls.responds(to: initSel) {
+                                let plugin = cls.init()
+                                rzp.perform(setSelector, with: plugin)
+                                break
+                            }
+                        }
+                    }
+                }
+            }
             
             DispatchQueue.main.async {
                 let cancelButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(self.handleCancelTap(sender:)))
@@ -211,7 +245,7 @@ extension RazorpayDelegate {
             if let dict = notification.userInfo {
                 if let uriScheme = dict["response"] as? String {
                     DispatchQueue.main.async {
-                        self.razorpay?.publishUri(with: uriScheme)
+                        try? self.razorpay?.publishUri(with: uriScheme)
                 }
             }
         }
@@ -248,6 +282,86 @@ extension RazorpayDelegate: WKNavigationDelegate {
     
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         self.razorpay?.webView(webView, didFailProvisionalNavigation: navigation, withError: error)
+    }
+}
+
+// MARK: - Amazon Pay Link-n-Pay
+extension RazorpayDelegate {
+
+    public func amazonPayStartAuthorization(customerId: String, result: @escaping FlutterResult) {
+        self.pendingResult = result
+
+        guard let rzp = self.razorpay else {
+            result(["type": "error", "data": ["code": -1, "message": "SDK not initialized"]])
+            return
+        }
+
+        let pluginSelector = NSSelectorFromString("amazonPlugin")
+        guard rzp.responds(to: pluginSelector),
+              let amazonModule = rzp.perform(pluginSelector)?.takeUnretainedValue() as? NSObject else {
+            result(["type": "error", "data": [
+                "code": -2,
+                "message": "amazonPlugin not set. Ensure SDK is initialized with Amazon Pay plugin."
+            ]])
+            return
+        }
+
+        callStartAuthorization(on: amazonModule, customerId: customerId, result: result)
+    }
+
+    private func callStartAuthorization(on module: NSObject, customerId: String, result: @escaping FlutterResult) {
+        let selectors = [
+            "startAuthorizationWithCustomerId:amazonAuthorizationDelegate:",
+            "startAuthorization:delegate:",
+            "startAuthorization:withDelegate:",
+            "startAuthorizationWithCustomerId:delegate:",
+        ]
+        for selName in selectors {
+            let sel = NSSelectorFromString(selName)
+            if module.responds(to: sel) {
+                module.perform(sel, with: customerId, with: self)
+                return
+            }
+        }
+
+        result(["type": "error", "data": [
+            "code": -3,
+            "message": "startAuthorization method not found on amazonPlugin"
+        ]])
+    }
+
+    /// Called by native SDK when Amazon Pay linking succeeds.
+    @objc func onLinkingSuccessful() {
+        let reply: [String: Any] = [
+            "type": "success",
+            "data": ["status": "linked"]
+        ]
+        pendingResult?(reply)
+    }
+
+    /// Called by native SDK when Amazon Pay linking fails.
+    @objc func onLinkingFailed(_ errorCode: Int, description: String) {
+        let reply: [String: Any] = [
+            "type": "error",
+            "data": ["code": errorCode, "message": description]
+        ]
+        pendingResult?(reply)
+    }
+
+    /// Checks if the Amazon Pay SDK is available.
+    public func isAmazonPayAvailable(result: @escaping FlutterResult) {
+        let classNames = [
+            "AMZNAuthorizationManager",
+            "AMZNLoginManager",
+            "AmazonWalletPaylater"
+        ]
+        for name in classNames {
+            if NSClassFromString(name) != nil {
+                result(true)
+                return
+            }
+        }
+        result(false)
     }
 }
 

--- a/ios/Classes/SwiftRazorpayFlutterCustomuiPlugin.swift
+++ b/ios/Classes/SwiftRazorpayFlutterCustomuiPlugin.swift
@@ -68,6 +68,14 @@ public class SwiftRazorpayFlutterCustomuiPlugin: NSObject, FlutterPlugin {
             if let vpa = call.arguments as? String {
                 razorpayDelegate.isValidVpa(value: vpa, result: result)
             }
+        // Amazon Pay Link-n-Pay
+        case "amazonPayStartAuthorization":
+            if let args = call.arguments as? Dictionary<String, Any>,
+               let customerId = args["customerId"] as? String {
+                razorpayDelegate.amazonPayStartAuthorization(customerId: customerId, result: result)
+            }
+        case "isAmazonPayAvailable":
+            razorpayDelegate.isAmazonPayAvailable(result: result)
         default:
             print("no method")
         }

--- a/ios/razorpay_flutter_customui.podspec
+++ b/ios/razorpay_flutter_customui.podspec
@@ -13,10 +13,11 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.platform = :ios, '10.0'
+  s.platform = :ios, '13.0'
 
   # s.vendored_frameworks = 'Frameworks/Razorpay.xcframework'
   s.dependency 'razorpay-customui-pod'
+  s.dependency 'razorpay-apay-wallet-paylater'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }

--- a/lib/amazon_pay.dart
+++ b/lib/amazon_pay.dart
@@ -1,0 +1,125 @@
+import 'package:eventify/eventify.dart';
+import 'package:flutter/services.dart';
+
+/// Amazon Pay wallet/paylater linking and payment support.
+///
+/// This class exposes the Amazon Pay Link-n-Pay flow for Flutter,
+/// bridging to the native Android (`amazonPayWallet.startAuthorization`)
+/// and iOS (`amazonPay?.startAuthorization`) SDKs.
+///
+/// Usage:
+/// ```dart
+/// final razorpay = Razorpay('rzp_test_xxx');
+///
+/// // 1. Link Amazon Pay account
+/// razorpay.amazonPay.startAuthorization(
+///   customerId: 'cust_xxx',
+///   onLinkingSuccessful: (data) {
+///     print('Linked! Token: ${data['token']}');
+///   },
+///   onLinkingFailed: (error) {
+///     print('Linking failed: $error');
+///   },
+/// );
+///
+/// // 2. Make wallet payment with linked token
+/// razorpay.submit({
+///   'key': 'rzp_test_xxx',
+///   'amount': 100,
+///   'currency': 'INR',
+///   'email': 'test@razorpay.com',
+///   'contact': '9999999999',
+///   'order_id': 'order_xxx',
+///   'customer_id': 'cust_xxx',
+///   'method': 'wallet',
+///   'wallet': 'amazonpay',
+///   'token': 'token_from_fetch_balance',
+/// });
+///
+/// // 3. Make paylater payment with linked token
+/// razorpay.submit({
+///   'key': 'rzp_test_xxx',
+///   'amount': 100,
+///   'currency': 'INR',
+///   'email': 'test@razorpay.com',
+///   'contact': '9999999999',
+///   'order_id': 'order_xxx',
+///   'customer_id': 'cust_xxx',
+///   'method': 'paylater',
+///   'provider': 'amazonpay',
+///   'token': 'token_from_fetch_balance',
+/// });
+/// ```
+class AmazonPay {
+  final MethodChannel _channel;
+  final EventEmitter _eventEmitter;
+
+  // Event names for Amazon Pay linking
+  static const EVENT_LINKING_SUCCESS = 'amazonpay.linking.success';
+  static const EVENT_LINKING_ERROR = 'amazonpay.linking.error';
+
+  AmazonPay(this._channel, this._eventEmitter);
+
+  /// Initiates the Amazon Pay account linking flow.
+  ///
+  /// This triggers the native Amazon Pay authorization on Android/iOS.
+  /// The user will be presented with the Amazon consent screen to link
+  /// their Amazon account with the merchant's Razorpay customer.
+  ///
+  /// Parameters:
+  /// - [customerId]: Razorpay customer ID (e.g. 'cust_xxx')
+  /// - [onLinkingSuccessful]: Called when linking succeeds. Receives a Map
+  ///   with linking details (varies by platform).
+  /// - [onLinkingFailed]: Called when linking fails. Receives error details.
+  ///
+  /// Android: Calls `razorpay.amazonPayWallet.startAuthorization(activity, customerId, callback)`
+  /// iOS: Calls `razorpay.amazonPay?.startAuthorization(customerId, delegate)`
+  Future<void> startAuthorization({
+    required String customerId,
+    required Function(Map<dynamic, dynamic> data) onLinkingSuccessful,
+    required Function(Map<dynamic, dynamic> error) onLinkingFailed,
+  }) async {
+    try {
+      final result = await _channel.invokeMethod(
+        'amazonPayStartAuthorization',
+        {'customerId': customerId},
+      );
+
+      if (result != null && result is Map) {
+        final resultMap = Map<dynamic, dynamic>.from(result);
+        if (resultMap['type'] == 'success') {
+          final data = resultMap['data'] != null
+              ? Map<dynamic, dynamic>.from(resultMap['data'] as Map)
+              : <dynamic, dynamic>{};
+          onLinkingSuccessful(data);
+          _eventEmitter.emit(EVENT_LINKING_SUCCESS, null, data);
+        } else {
+          final error = resultMap['data'] != null
+              ? Map<dynamic, dynamic>.from(resultMap['data'] as Map)
+              : <dynamic, dynamic>{'message': 'Unknown error'};
+          onLinkingFailed(error);
+          _eventEmitter.emit(EVENT_LINKING_ERROR, null, error);
+        }
+      }
+    } on PlatformException catch (e) {
+      final error = <dynamic, dynamic>{
+        'code': e.code,
+        'message': e.message ?? 'Platform error during Amazon Pay linking',
+      };
+      onLinkingFailed(error);
+      _eventEmitter.emit(EVENT_LINKING_ERROR, null, error);
+    }
+  }
+
+  /// Checks if the Amazon Pay plugin/SDK is available on this device.
+  ///
+  /// Returns `true` if the native Amazon Pay SDK classes are present.
+  Future<bool> isAvailable() async {
+    try {
+      final result = await _channel.invokeMethod('isAmazonPayAvailable');
+      return result == true;
+    } catch (_) {
+      return false;
+    }
+  }
+}

--- a/lib/razorpay_flutter_customui.dart
+++ b/lib/razorpay_flutter_customui.dart
@@ -3,6 +3,7 @@ import 'package:eventify/eventify.dart';
 import 'package:flutter/services.dart';
 import 'Tpv.dart';
 import 'upi_turbo.dart';
+import 'amazon_pay.dart';
 
 class Razorpay  {
   // Response codes from platform
@@ -25,12 +26,14 @@ class Razorpay  {
   late EventEmitter _eventEmitter;
   late UpiTurbo upiTurbo;
   late Tpv tpv;
+  late AmazonPay amazonPay;
 
   Razorpay(String key) {
     _channel.invokeMethod('initilizeSDK', key);
     _eventEmitter = new EventEmitter();
     upiTurbo = new UpiTurbo( _channel, _eventEmitter);
     tpv = Tpv(_channel , _eventEmitter);
+    amazonPay = AmazonPay(_channel, _eventEmitter);
   }
 
   // Maintain a map to store callbacks for each data exchange


### PR DESCRIPTION
Razorpay's Flutter plugin doesn't let merchant link a customer's Amazon account. We need to add a new "Amazon Pay linking" feature to the Flutter plugin so merchants can trigger the Amazon account linking flow directly from their Flutter app, just like they already can on web, Android, and iOS.

| Test Case Document URL                        |
|-----------------------------------------------|
| Please paste test case document link here.... |
