### PR TITLE
[WIP] feat(apple-pay): Apple Pay wrapper for Custom Checkout (unbuilt, needs device QA)

### DIFF
--- a/ios/Classes/RazorpayDelegate.swift
+++ b/ios/Classes/RazorpayDelegate.swift
@@ -244,23 +244,27 @@ extension RazorpayDelegate {
                 }
             }
 
-            // Attach Apple Pay plugin, mirroring the Amazon Pay reflective pattern.
-            // The RazorpayApplePay module ships ApplePayEntity (the ApplePayPlugin
-            // conformer). initiate(key_id:) must run before the plugin is set, matching
-            // what RazorpayCheckout.initWithKey(...ApplePay:) does internally.
-            // TODO(verify): confirm the class name + selectors against the linked
-            // RazorpayApplePay 2.2.0 symbols before device QA.
-            if let rzp = self.razorpay {
-                let applePayEntityClassName = "RazorpayApplePay.ApplePayEntity"
+            // Attach the Apple Pay plugin using the API-Council-approved factory
+            // ApplePay.pluginInstance() (module RazorpayApplePay) rather than
+            // instantiating an entity directly. initiate(key_id:) must run before the
+            // plugin is set, matching RazorpayCheckout.initWithKey(...ApplePay:) internally.
+            // TODO(verify): confirm ApplePay.pluginInstance() is reachable via the ObjC
+            // runtime (perform) and the setApplePay: / initiateWithKey_id: selectors
+            // against the linked RazorpayApplePay 2.2.0 module. (Amazon Pay had to
+            // instantiate its entity directly because its factory was not @objc — confirm
+            // whether ApplePay.pluginInstance() is exposed to the ObjC runtime.)
+            if let rzp = self.razorpay,
+               let applePayCls = NSClassFromString("RazorpayApplePay.ApplePay") as AnyObject? {
+                let pluginInstanceSel = NSSelectorFromString("pluginInstance")
                 let setApplePaySel = NSSelectorFromString("setApplePay:")
-                if let entityCls = NSClassFromString(applePayEntityClassName) as? NSObject.Type,
-                   rzp.responds(to: setApplePaySel) {
-                    let entity = entityCls.init()
+                if applePayCls.responds(to: pluginInstanceSel),
+                   rzp.responds(to: setApplePaySel),
+                   let plugin = applePayCls.perform(pluginInstanceSel)?.takeUnretainedValue() as? NSObject {
                     let initiateSel = NSSelectorFromString("initiateWithKey_id:")
-                    if entity.responds(to: initiateSel) {
-                        entity.perform(initiateSel, with: key)
+                    if plugin.responds(to: initiateSel) {
+                        plugin.perform(initiateSel, with: key)
                     }
-                    rzp.perform(setApplePaySel, with: entity)
+                    rzp.perform(setApplePaySel, with: plugin)
                 }
             }
 

--- a/ios/Classes/RazorpayDelegate.swift
+++ b/ios/Classes/RazorpayDelegate.swift
@@ -243,6 +243,26 @@ extension RazorpayDelegate {
                 }
             }
 
+            // Attach Apple Pay plugin, mirroring the Amazon Pay reflective pattern.
+            // The RazorpayApplePay module ships ApplePayEntity (the ApplePayPlugin
+            // conformer). initiate(key_id:) must run before the plugin is set, matching
+            // what RazorpayCheckout.initWithKey(...ApplePay:) does internally.
+            // TODO(verify): confirm the class name + selectors against the linked
+            // RazorpayApplePay 2.2.0 symbols before device QA.
+            if let rzp = self.razorpay {
+                let applePayEntityClassName = "RazorpayApplePay.ApplePayEntity"
+                let setApplePaySel = NSSelectorFromString("setApplePay:")
+                if let entityCls = NSClassFromString(applePayEntityClassName) as? NSObject.Type,
+                   rzp.responds(to: setApplePaySel) {
+                    let entity = entityCls.init()
+                    let initiateSel = NSSelectorFromString("initiateWithKey_id:")
+                    if entity.responds(to: initiateSel) {
+                        entity.perform(initiateSel, with: key)
+                    }
+                    rzp.perform(setApplePaySel, with: entity)
+                }
+            }
+
             DispatchQueue.main.async {
                 let cancelButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(self.handleCancelTap(sender:)))
                 
@@ -408,6 +428,26 @@ extension RazorpayDelegate {
             return
         }
         let pluginSelector = NSSelectorFromString("amazonPlugin")
+        if rzp.responds(to: pluginSelector),
+           let plugin = rzp.perform(pluginSelector)?.takeUnretainedValue() {
+            result(plugin is NSObject)
+        } else {
+            result(false)
+        }
+    }
+
+    // MARK: - Apple Pay
+
+    /// Device capability for Apple Pay. Mirrors `isAmazonPayAvailable`: reports
+    /// whether the Apple Pay plugin is attached on the checkout instance.
+    /// TODO(verify): confirm the `applePay` accessor selector against the
+    /// RazorpayApplePay module once the SPM/pod dependency is wired.
+    public func isApplePayAvailable(result: @escaping FlutterResult) {
+        guard let rzp = self.razorpay else {
+            result(false)
+            return
+        }
+        let pluginSelector = NSSelectorFromString("applePay")
         if rzp.responds(to: pluginSelector),
            let plugin = rzp.perform(pluginSelector)?.takeUnretainedValue() {
             result(plugin is NSObject)

--- a/ios/Classes/RazorpayDelegate.swift
+++ b/ios/Classes/RazorpayDelegate.swift
@@ -244,22 +244,30 @@ extension RazorpayDelegate {
                 }
             }
 
-            // Attach the Apple Pay plugin using the API-Council-approved factory
-            // ApplePay.pluginInstance() (module RazorpayApplePay) rather than
-            // instantiating an entity directly. initiate(key_id:) must run before the
-            // plugin is set, matching RazorpayCheckout.initWithKey(...ApplePay:) internally.
-            // TODO(verify): confirm ApplePay.pluginInstance() is reachable via the ObjC
-            // runtime (perform) and the setApplePay: / initiateWithKey_id: selectors
-            // against the linked RazorpayApplePay 2.2.0 module. (Amazon Pay had to
-            // instantiate its entity directly because its factory was not @objc — confirm
-            // whether ApplePay.pluginInstance() is exposed to the ObjC runtime.)
-            if let rzp = self.razorpay,
-               let applePayCls = NSClassFromString("RazorpayApplePay.ApplePay") as AnyObject? {
-                let pluginInstanceSel = NSSelectorFromString("pluginInstance")
+            // Attach the Apple Pay plugin (same runtime mechanism as Amazon Pay above).
+            // The merchant-facing factory is the API-Council-approved
+            // ApplePay.pluginInstance() (module RazorpayApplePay). We do NOT call it here
+            // reflectively: like Amazon's pluginInstance(), a Swift static is not exposed
+            // to the Obj-C runtime, and this module does not import RazorpayApplePay. So
+            // internally we instantiate the plugin's concrete conformer and call
+            // initiate(key_id:) before setApplePay:, mirroring the Amazon slice.
+            //
+            // DECISION FOR THE SDK TEAM (see PR thread):
+            //  (a) native/preferred: import RazorpayApplePay in this plugin and use the
+            //      typed init RazorpayCheckout.initWithKey(..., ApplePay: ApplePay.pluginInstance())
+            //      — compiler-checked, uses the council factory literally, no reflection.
+            //      Requires the Flutter distribution to vend RazorpayApplePay (2.2.0 is
+            //      SPM-only today, so this needs the packaging call first).
+            //  (b) reflection (below): works with the existing CocoaPods dependency, no
+            //      hard module import; needs the concrete conformer + selectors confirmed.
+            // TODO(verify): concrete conformer class name + setApplePay:/initiateWithKey_id:
+            //   against RazorpayApplePay 2.2.0.
+            if let rzp = self.razorpay {
+                let pluginClassName = "RazorpayApplePay.ApplePayEntity" // TODO(verify) conformer
                 let setApplePaySel = NSSelectorFromString("setApplePay:")
-                if applePayCls.responds(to: pluginInstanceSel),
-                   rzp.responds(to: setApplePaySel),
-                   let plugin = applePayCls.perform(pluginInstanceSel)?.takeUnretainedValue() as? NSObject {
+                if let pluginCls = NSClassFromString(pluginClassName) as? NSObject.Type,
+                   rzp.responds(to: setApplePaySel) {
+                    let plugin = pluginCls.init()
                     let initiateSel = NSSelectorFromString("initiateWithKey_id:")
                     if plugin.responds(to: initiateSel) {
                         plugin.perform(initiateSel, with: key)

--- a/ios/Classes/RazorpayDelegate.swift
+++ b/ios/Classes/RazorpayDelegate.swift
@@ -1,4 +1,5 @@
 import Flutter
+import PassKit
 import Razorpay
 import WebKit
 
@@ -438,21 +439,11 @@ extension RazorpayDelegate {
 
     // MARK: - Apple Pay
 
-    /// Device capability for Apple Pay. Mirrors `isAmazonPayAvailable`: reports
-    /// whether the Apple Pay plugin is attached on the checkout instance.
-    /// TODO(verify): confirm the `applePay` accessor selector against the
-    /// RazorpayApplePay module once the SPM/pod dependency is wired.
+    /// Device capability for Apple Pay via PassKit (device + Wallet). Matches the
+    /// React Native wrapper and the native ApplePay.isApplePaySupported() gate.
+    /// This is a real eligibility check (not merely "is the plugin attached"),
+    /// so the merchant only shows the Apple Pay button when a payment can be made.
     public func isApplePayAvailable(result: @escaping FlutterResult) {
-        guard let rzp = self.razorpay else {
-            result(false)
-            return
-        }
-        let pluginSelector = NSSelectorFromString("applePay")
-        if rzp.responds(to: pluginSelector),
-           let plugin = rzp.perform(pluginSelector)?.takeUnretainedValue() {
-            result(plugin is NSObject)
-        } else {
-            result(false)
-        }
+        result(PKPaymentAuthorizationController.canMakePayments())
     }
 }

--- a/ios/Classes/SwiftRazorpayFlutterCustomuiPlugin.swift
+++ b/ios/Classes/SwiftRazorpayFlutterCustomuiPlugin.swift
@@ -75,6 +75,8 @@ public class SwiftRazorpayFlutterCustomuiPlugin: NSObject, FlutterPlugin {
             }
         case "isAmazonPayAvailable":
             razorpayDelegate.isAmazonPayAvailable(result: result)
+        case "isApplePayAvailable":
+            razorpayDelegate.isApplePayAvailable(result: result)
         default:
             print("no method")
         }

--- a/ios/razorpay_flutter_customui.podspec
+++ b/ios/razorpay_flutter_customui.podspec
@@ -18,6 +18,9 @@ Pod::Spec.new do |s|
   # s.vendored_frameworks = 'Frameworks/Razorpay.xcframework'
   s.dependency 'razorpay-customui-pod', '~> 2.1.0'
 
+  # Apple Pay capability check uses PKPaymentAuthorizationController.
+  s.frameworks = 'PassKit'
+
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
   s.swift_version = '5.0'

--- a/lib/apple_pay.dart
+++ b/lib/apple_pay.dart
@@ -9,8 +9,8 @@ import 'package:flutter/services.dart';
 ///   final razorpay = Razorpay();
 ///   razorpay.initilizeSDK('rzp_xxx');
 ///
-///   // 1. Check availability (gate the Apple Pay button)
-///   bool available = await razorpay.applePay.isAvailable();
+///   // 1. Check eligibility (gate the Apple Pay button)
+///   bool available = await razorpay.applePay.canMakePayment();
 ///
 ///   // 2. Pay — existing submit(), Apple Pay selected by options
 ///   razorpay.submit({
@@ -32,10 +32,11 @@ class ApplePay {
 
   ApplePay(this._channel, this._eventEmitter);
 
-  /// Returns true if this device can present Apple Pay (Wallet + an eligible
-  /// card). Always false on the simulator. Use it to show/hide the Apple Pay
-  /// button.
-  Future<bool> isAvailable() async {
+  /// Whether Apple Pay can be used (device + Wallet). Named `canMakePayment`
+  /// per the API Council decision (aligned with the Web SDK and the native
+  /// SDK's `razorpay.applePay.canMakePayment`). Always false on the simulator.
+  /// Use it to show/hide the Apple Pay button.
+  Future<bool> canMakePayment() async {
     try {
       final result = await _channel.invokeMethod('isApplePayAvailable');
       return result == true;

--- a/lib/apple_pay.dart
+++ b/lib/apple_pay.dart
@@ -1,0 +1,46 @@
+import 'package:eventify/eventify.dart';
+import 'package:flutter/services.dart';
+
+/// Apple Pay support (iOS only), modelled on the Amazon Pay slice.
+///
+/// The payment itself flows through the existing `razorpay.submit()` with the
+/// Apple Pay options block, so no new payment-method name is introduced:
+///
+///   final razorpay = Razorpay();
+///   razorpay.initilizeSDK('rzp_xxx');
+///
+///   // 1. Check availability (gate the Apple Pay button)
+///   bool available = await razorpay.applePay.isAvailable();
+///
+///   // 2. Pay — existing submit(), Apple Pay selected by options
+///   razorpay.submit({
+///     'key': 'rzp_xxx',
+///     'order_id': 'order_xxx',
+///     'amount': '50000',
+///     'currency': 'INR',
+///     'method': 'card',
+///     'app': {
+///       'name': 'apple_pay',
+///       'apple_pay': {'merchant_identifier': 'merchant.com.yourcompany.app'},
+///     },
+///   });
+class ApplePay {
+  final MethodChannel _channel;
+  // Kept for parity with AmazonPay (future events); unused for the capability check.
+  // ignore: unused_field
+  final EventEmitter _eventEmitter;
+
+  ApplePay(this._channel, this._eventEmitter);
+
+  /// Returns true if this device can present Apple Pay (Wallet + an eligible
+  /// card). Always false on the simulator. Use it to show/hide the Apple Pay
+  /// button.
+  Future<bool> isAvailable() async {
+    try {
+      final result = await _channel.invokeMethod('isApplePayAvailable');
+      return result == true;
+    } catch (_) {
+      return false;
+    }
+  }
+}

--- a/lib/razorpay_flutter_customui.dart
+++ b/lib/razorpay_flutter_customui.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:eventify/eventify.dart';
 import 'package:flutter/services.dart';
 import 'amazon_pay.dart';
+import 'apple_pay.dart';
 
 class Razorpay {
   // Response codes from platform
@@ -26,10 +27,12 @@ class Razorpay {
   // EventEmitter instance used for communication
   late EventEmitter _eventEmitter;
   late AmazonPay amazonPay;
+  late ApplePay applePay;
 
   Razorpay() {
     _eventEmitter = new EventEmitter();
     amazonPay = AmazonPay(_channel, _eventEmitter);
+    applePay = ApplePay(_channel, _eventEmitter);
   }
 
   Future<Map<dynamic, dynamic>> getPaymentMethods() async {

--- a/test/apple_pay_test.dart
+++ b/test/apple_pay_test.dart
@@ -43,9 +43,9 @@ void main() {
     razorpay.clear();
   });
 
-  group('ApplePay.isAvailable', () {
+  group('ApplePay.canMakePayment', () {
     test('invokes isApplePayAvailable and returns the bool', () async {
-      final available = await razorpay.applePay.isAvailable();
+      final available = await razorpay.applePay.canMakePayment();
       expect(log, <Matcher>[isMethodCall('isApplePayAvailable', arguments: null)]);
       expect(available, isTrue);
     });

--- a/test/apple_pay_test.dart
+++ b/test/apple_pay_test.dart
@@ -1,0 +1,71 @@
+// Unit tests for the Apple Pay wrapper — device-independent.
+// Mirrors the razorpay-flutter test convention: MethodChannel `log` +
+// `isMethodCall` assertions + `expectAsync1` for eventify callbacks.
+// Run with: flutter test
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:razorpay_flutter_customui/razorpay_flutter_customui.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('razorpay_flutter_customui');
+  final List<MethodCall> log = <MethodCall>[];
+  late Razorpay razorpay;
+
+  final applePayOptions = <String, dynamic>{
+    'key': 'rzp_test_key',
+    'order_id': 'order_1',
+    'amount': '50000',
+    'currency': 'INR',
+    'contact': '9999999999',
+    'email': 'user@example.com',
+    'method': 'card',
+    'app': {
+      'name': 'apple_pay',
+      'apple_pay': {'merchant_identifier': 'merchant.com.x'},
+    },
+  };
+
+  setUp(() {
+    channel.setMockMethodCallHandler((MethodCall call) async {
+      log.add(call);
+      if (call.method == 'isApplePayAvailable') return true;
+      return <String, dynamic>{};
+    });
+    razorpay = Razorpay();
+    log.clear();
+  });
+
+  tearDown(() {
+    channel.setMockMethodCallHandler(null);
+    razorpay.clear();
+  });
+
+  group('ApplePay.isAvailable', () {
+    test('invokes isApplePayAvailable and returns the bool', () async {
+      final available = await razorpay.applePay.isAvailable();
+      expect(log, <Matcher>[isMethodCall('isApplePayAvailable', arguments: null)]);
+      expect(available, isTrue);
+    });
+  });
+
+  group('submit with apple_pay options', () {
+    test('passes the apple_pay options through to native submit', () async {
+      razorpay.submit(applePayOptions);
+      expect(log, <Matcher>[isMethodCall('submit', arguments: applePayOptions)]);
+    });
+
+    test('fires payment.error (INVALID_OPTIONS) when key is missing', () async {
+      final bad = Map<String, dynamic>.of(applePayOptions)..remove('key');
+      razorpay.on(
+        Razorpay.EVENT_PAYMENT_ERROR,
+        expectAsync1((dynamic response) {
+          expect(response, isNotNull);
+        }, count: 1),
+      );
+      razorpay.submit(bad);
+    });
+  });
+}

--- a/test/apple_pay_test.dart
+++ b/test/apple_pay_test.dart
@@ -57,15 +57,12 @@ void main() {
       expect(log, <Matcher>[isMethodCall('submit', arguments: applePayOptions)]);
     });
 
-    test('fires payment.error (INVALID_OPTIONS) when key is missing', () async {
+    test('missing key short-circuits before native submit', () async {
+      // _validateOptions fails on a missing key, so submit() must not reach the
+      // native channel. (Avoids on()/_resync emit noise in the mock.)
       final bad = Map<String, dynamic>.of(applePayOptions)..remove('key');
-      razorpay.on(
-        Razorpay.EVENT_PAYMENT_ERROR,
-        expectAsync1((dynamic response) {
-          expect(response, isNotNull);
-        }, count: 1),
-      );
       razorpay.submit(bad);
+      expect(log.where((c) => c.method == 'submit'), isEmpty);
     });
   });
 }


### PR DESCRIPTION
## What
Adds **Apple Pay** to the Flutter Custom Checkout SDK, mirroring the existing **Amazon Pay** slice. Payment flows through the existing `razorpay.submit()` with `method:"card"` + `app.apple_pay`, so **no new payment-method name** is introduced (aligns with the native Apple Pay API council decision).

## Changes
- `lib/apple_pay.dart` — `ApplePay(_channel, _eventEmitter).isAvailable()` (capability gate)
- `lib/razorpay_flutter_customui.dart` — `applePay` sub-object wired in the constructor
- `ios/Classes/SwiftRazorpayFlutterCustomuiPlugin.swift` — `isApplePayAvailable` channel case
- `ios/Classes/RazorpayDelegate.swift` — `isApplePayAvailable` delegate + reflective plugin attach (modelled on the Amazon Pay pattern)
- `test/apple_pay_test.dart` — device-independent unit tests (`flutter test`)

## Status — DO NOT MERGE
- 🟡 **Unbuilt / not compiled** here (no Flutter SDK / Xcode in the drafting env).
- 🟡 **iOS reflective attach** (`RazorpayApplePay.ApplePayEntity`, `setApplePay:`, `initiateWithKey_id:`) is modelled on the Amazon Pay reflective pattern and needs **symbol verification** against the linked `RazorpayApplePay` 2.2.0 module. Marked `TODO(verify)` in code.
- 🟡 **SDK packaging** (RazorpayApplePay via SPM 2.2.0) is a separate follow-up.
- 🟡 **Device E2E** on the sandbox rig is required (Apple Pay cannot run on simulator).

## Ownership
Drafted by the cross-border pod as a hand-off for the mobile SDK team (owners of this repo). Please review the Dart contract + tests; the iOS attach is scaffolding to complete + verify on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)